### PR TITLE
Remove format string artifact in HTTPS url

### DIFF
--- a/net/known_http_apis.txt
+++ b/net/known_http_apis.txt
@@ -1,2 +1,2 @@
 https://api.readyatdawn.com
-https://api-%s.readyatdawn.com # what's %s??
+https://api-*.readyatdawn.com


### PR DESCRIPTION
%s is a special type field character for functions like printf and scanf. %s is not part of the actual url, but instead would be the place where another string would take it's place programmatically. Hence, I have replaced it with a wildcard to show that